### PR TITLE
Remve all leading and trailing whitespace

### DIFF
--- a/zomg/mdterm/slide_display.go
+++ b/zomg/mdterm/slide_display.go
@@ -65,7 +65,7 @@ func (r *RenderedSlide) DisplayWithOptions(opt *DisplayOptions) error {
 			break
 		case ex:
 			// Execute a command
-			execStr := e.RawString()
+			execStr := strings.Trim(e.RawString(), " ")
 			logger.Info("exec: %s", execStr)
 			execSlc := strings.Split(execStr, " ")
 			cmd := exec.Command(execSlc[0], execSlc[1:]...)


### PR DESCRIPTION
exec was failing for me as the space between `$` and `whoami` was being interpreted as the comment to run